### PR TITLE
don't use the root logger

### DIFF
--- a/anyblock_exporter.py
+++ b/anyblock_exporter.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from anyblock_exporter import (
@@ -21,7 +22,7 @@ def main():
 
     # Setup logging
     setup_logger(log_level, log_file)
-    logger = get_logger(__name__)
+    logger = logging.getLogger("anyblock_exporter")
 
     logger.info("Starting Anytype to Markdown conversion")
 

--- a/anyblock_exporter/__init__.py
+++ b/anyblock_exporter/__init__.py
@@ -2,7 +2,7 @@
 
 from .cli import parse_arguments
 from .config_loader import config
-from .logger import setup_logger, get_logger
+from .logger import setup_logger
 from .converter import AnytypeConverter
 from .block_converter import convert_block_to_markdown
 from .relation_handler import RelationHandler

--- a/anyblock_exporter/block_converter.py
+++ b/anyblock_exporter/block_converter.py
@@ -2,6 +2,8 @@ import logging
 from typing import Dict, Any, List
 from anyblock_exporter.utils import format_inline_text, convert_table_to_markdown, format_latex_equation
 
+LOGGER = logging.getLogger("anyblock_exporter")
+
 def is_organizational_block(block: Dict[str, Any]) -> bool:
     """Determine if a block is an organizational block."""
     return block.get('layout', {}).get('style') == 'Div' or not block.get('text', {}).get('text', '')
@@ -94,7 +96,7 @@ def convert_block_to_markdown(block: Dict[str, Any], all_blocks: Dict[str, Any],
         table = convert_table_to_markdown(block)
         markdown += apply_indent(table) + "\n"
     else:
-        logging.warning(f"Unknown block type: {block_type}")
+        LOGGER.warning(f"Unknown block type: {block_type}")
         markdown += apply_indent(content) + "\n\n"
 
     # Process other children

--- a/anyblock_exporter/file_handler.py
+++ b/anyblock_exporter/file_handler.py
@@ -9,6 +9,7 @@ class FileHandler:
     def __init__(self, attachments_folder: str):
         self.attachments_folder = attachments_folder
         self.files_to_copy = {}
+        self.logger = logging.getLogger("anyblock_exporter")
 
     def handle_file_attachment(self, file_info: Dict[str, Any]) -> str:
         file_name = file_info.get('name', 'unnamed_file')
@@ -27,4 +28,4 @@ class FileHandler:
             if os.path.exists(source_path):
                 shutil.copy2(source_path, dest_path)
             else:
-                logging.warning(f"File not found: {source_path}")
+                self.logger.warning(f"File not found: {source_path}")

--- a/anyblock_exporter/logger.py
+++ b/anyblock_exporter/logger.py
@@ -7,6 +7,3 @@ def setup_logger(log_level, log_file):
         format='%(asctime)s - %(levelname)s - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
-
-def get_logger(name):
-    return logging.getLogger(name)

--- a/anyblock_exporter/relation_handler.py
+++ b/anyblock_exporter/relation_handler.py
@@ -11,6 +11,7 @@ class RelationHandler:
         self.decode_timestamps = config.get('decode_timestamps', True)
         self.ignored_properties = config.get('ignored_properties', [])
         self.link_mode = config.get('turn_relations_into_obsidian_links', 'select')
+        self.logger = logging.getLogger("anyblock_exporter")
 
     def convert_timestamp_if_applicable(self, value: Any) -> Tuple[str, bool]:
         is_date = False
@@ -22,7 +23,7 @@ class RelationHandler:
                 is_date = True
                 return adjusted_date.strftime("%Y-%m-%d"), is_date
             except Exception as e:
-                logging.warning(f"Failed to convert timestamp {value}: {str(e)}")
+                self.logger.warning(f"Failed to convert timestamp {value}: {str(e)}")
         return self.get_relation_option_name(value), is_date
 
     def extract_relations(self, main_content: Dict[str, Any]) -> List[str]:
@@ -56,7 +57,7 @@ class RelationHandler:
                 formatted_relations.append(f"{relation_name}:")
                 formatted_relations.extend(f" - {value}" for value in values)
 
-        logging.debug(f"Extracted relations: {formatted_relations}")
+        self.logger.debug(f"Extracted relations: {formatted_relations}")
         return formatted_relations
 
     def format_relation_value(self, value: Any, key: str) -> str:
@@ -92,7 +93,7 @@ class RelationHandler:
                 self.relation_cache[relation_key] = obj['snapshot']['data']['details']
                 return self.relation_cache[relation_key]
 
-        logging.warning(f"Relation info not found for key: {relation_key}")
+        self.logger.warning(f"Relation info not found for key: {relation_key}")
         return {}
 
     def get_relation_option_name(self, option_id: str) -> str:


### PR DESCRIPTION
From the [Python documentation](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):

> It is strongly advised that you do not log to the root logger in your library. Instead, use a logger with a unique and easily identifiable name

Related: https://github.com/jfcostello/AnyBlock-To-Markdown/issues/2