### PR TITLE
Minimal module setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,11 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [project]
 name = "anyblock_exporter"
 version = "0.0.1"
+dynamic = ["dependencies"]
+
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "anyblock_exporter"
+version = "0.0.1"


### PR DESCRIPTION
Closes: https://github.com/jfcostello/AnyBlock-To-Markdown/issues/2

This PR adds a minimal `pyproject.toml`. It's not sufficient for a release on Pypi, but enough for my needs. I was able to integrate it successfully in a [PoC](https://github.com/marph91/jimmy/blob/ff450e63d743506fef8f21e2b934b8d500048544/requirements/requirements.txt#L1).